### PR TITLE
NanoID v3 compatability & numbers as letters filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install nanoid-good
 
 ```js
 var en = require("nanoid-good/locale/en"); // you should add locale of your preferred language
-var nanoid = require("nanoid-good").nanonid(en);
+var nanoid = require("nanoid-good").nanoid(en);
 var id = nanoid(); //=> "V1StGXR8_Z5jdHi6B~myT"
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install nanoid-good
 
 ```js
 var en = require("nanoid-good/locale/en"); // you should add locale of your preferred language
-var nanoid = require("nanoid-good")(en);
+var nanoid = require("nanoid-good").nanonid(en);
 var id = nanoid(); //=> "V1StGXR8_Z5jdHi6B~myT"
 ```
 
@@ -35,19 +35,19 @@ You can also use several locales:
 ```js
 var en = require("nanoid-good/locale/en");
 var ru = require("nanoid-good/locale/ru");
-var nanoid = require("nanoid-good")(en, ru);
+var nanoid = require("nanoid-good").nanoid(en, ru);
 ```
 
 All additional functions of **Nano ID** are supported too:
 
 ```js
 var en = require("nanoid-good/locale/en");
-var format = require("nanoid-good/format")(en);
-var generate = require("nanoid-good/generate")(en);
-var nonSecure = require("nanoid-good/non-secure")(en);
+var customRandom = require("nanoid-good").customRandom(en);
+var customAlphabet = require("nanoid-good").customAlphabet(en);
+var nonSecure = require("nanoid-good/non-secure").nanoid(en);
 
-var id1 = format(random, "abcdef", 5);
-var id2 = generate("1234567abcdef", 10);
+var id1 = customRandom("abcdef", 5, randomFunc);
+var id2 = customAlphabet("1234567abcdef", 10);
 var id3 = nonSecure();
 ```
 
@@ -57,13 +57,13 @@ You can use async versions of `nanoid` functions the same way as you use them in
 
 ```js
 var en = require("nanoid-good/locale/en");
-var nanoid = require("nanoid-good/async")(en);
-var format = require("nanoid-good/async/format")(en);
-var generate = require("nanoid-good/async/generate")(en);
+var nanoid = require("nanoid-good/async").nanonid(en);
+var customRandom = require("nanoid-good/async").customRandom(en);
+var customAlphabet = require("nanoid-good/async").customAlphabet(en);
 
 async function generateIds() {
   var id1 = await nanoid();
-  var id2 = await format(random, "abcdef", 5);
-  var id3 = await generate("1234567abcdef", 10);
+  var id2 = await customRandom("abcdef", 5, random);
+  var id3 = await customAlphabet("1234567abcdef", 10);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can use async versions of `nanoid` functions the same way as you use them in
 
 ```js
 var en = require("nanoid-good/locale/en");
-var nanoid = require("nanoid-good/async").nanonid(en);
+var nanoid = require("nanoid-good/async").nanoid(en);
 var customRandom = require("nanoid-good/async").customRandom(en);
 var customAlphabet = require("nanoid-good/async").customAlphabet(en);
 

--- a/async/format.js
+++ b/async/format.js
@@ -1,4 +1,0 @@
-var format = require('nanoid/async/format');
-var wrapper = require('./wrapper');
-
-module.exports = wrapper(format);

--- a/async/generate.js
+++ b/async/generate.js
@@ -1,4 +1,0 @@
-var generate = require('nanoid/async/generate');
-var wrapper = require('./wrapper');
-
-module.exports = wrapper(generate);

--- a/async/index.js
+++ b/async/index.js
@@ -1,4 +1,8 @@
 var nanoid = require('nanoid/async');
 var wrapper = require('./wrapper');
 
-module.exports = wrapper(nanoid);
+module.exports = {
+    nanoid: wrapper(nanoid.nanoid),
+    customAlphabet: (...locales) => (alphabet, size) => wrapper(nanoid.customAlphabet(alphabet, size))(...locales),
+    random: nanoid.random
+}

--- a/format.js
+++ b/format.js
@@ -1,4 +1,0 @@
-var format = require('nanoid/format');
-var wrapper = require('./wrapper');
-
-module.exports = wrapper(format);

--- a/generate.js
+++ b/generate.js
@@ -1,4 +1,0 @@
-var generate = require('nanoid/generate');
-var wrapper = require('./wrapper');
-
-module.exports = wrapper(generate);

--- a/hasProfanity.js
+++ b/hasProfanity.js
@@ -1,6 +1,8 @@
 function checkByList(input, bad_words) {
     for (var i = 0; i < bad_words.length; i++) {
-        if (new RegExp(bad_words[i], "gi").test(input)) return true;
+        // Number 1 can be interpreted as l or I.
+        var sanitizedBadWord = bad_words[i].replace('l', 'i')
+        if (new RegExp(sanitizedBadWord, "gi").test(input)) return true;
     }
     return false;
 }
@@ -12,8 +14,15 @@ var hasProfanityFactory = function () {
         return false;
     }
     return function (input) {
+        var inputWithNumbersReplaced = input
+            .replace('1', 'i')
+            .replace('3', 'e')
+            .replace('5', 's')
+            .replace('8', 'b')
+            .replace('0', 'o')
+        
         for (var i = 0; i < list.length; i++) {
-            if (checkByList(input, list[i])) return true;
+            if (checkByList(inputWithNumbersReplaced, list[i])) return true;
         }
         return false;
     };

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var wrapper = require('./wrapper');
 
 module.exports = {
     nanoid: wrapper(nanoid.nanoid),
-    customAlphabet: wrapper(nanoid.customAlphabet),
-    customRandom: wrapper(nanoid.customRandom), 
+    customAlphabet: (...locales) => (alphabet, size) => wrapper(nanoid.customAlphabet(alphabet, size))(...locales),
+    customRandom: (...locales) => (alphabet, size, randomFunc) => wrapper(nanoid.customRandom(alphabet, size, randomFunc))(...locales), 
     urlAlphabet: nanoid.urlAlphabet, 
     random: nanoid.random
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 var nanoid = require('nanoid');
 var wrapper = require('./wrapper');
 
-module.exports = wrapper(nanoid);
+module.exports = {
+    nanoid: wrapper(nanoid.nanoid),
+    customAlphabet: wrapper(nanoid.customAlphabet),
+    customRandom: wrapper(nanoid.customRandom), 
+    urlAlphabet: nanoid.urlAlphabet, 
+    random: nanoid.random
+}

--- a/non-secure.js
+++ b/non-secure.js
@@ -1,4 +1,0 @@
-var nonSecure = require('nanoid/non-secure');
-var wrapper = require('./wrapper');
-
-module.exports = wrapper(nonSecure);

--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -4,8 +4,8 @@ var wrapper = require('../wrapper');
 
 module.exports = {
     nanoid: wrapper(nsnanoid.nanoid),
-    customAlphabet: wrapper(nsnanoid.customAlphabet),
-    customRandom: wrapper(nanoid.customRandom), 
+    customAlphabet: (...locales) => (alphabet, size) => wrapper(nsnanoid.customAlphabet(alphabet, size))(...locales),
+    customRandom: (...locales) => (alphabet, size, randomFunc) => wrapper(nanoid.customRandom(alphabet, size, randomFunc))(...locales), 
     urlAlphabet: nanoid.urlAlphabet, 
     random: nanoid.random
 }

--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -1,0 +1,11 @@
+var nsnanoid = require('nanoid/non-secure');
+var nanoid = require('nanoid');
+var wrapper = require('../wrapper');
+
+module.exports = {
+    nanoid: wrapper(nsnanoid.nanoid),
+    customAlphabet: wrapper(nsnanoid.customAlphabet),
+    customRandom: wrapper(nanoid.customRandom), 
+    urlAlphabet: nanoid.urlAlphabet, 
+    random: nanoid.random
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoid-good",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -362,6 +362,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2791,7 +2792,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2812,12 +2814,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2832,17 +2836,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2959,7 +2966,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2971,6 +2979,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2985,6 +2994,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2992,12 +3002,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3016,6 +3028,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3096,7 +3109,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3108,6 +3122,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3193,7 +3208,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3229,6 +3245,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3248,6 +3265,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3291,12 +3309,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4707,7 +4727,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5056,9 +5077,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.0.tgz",
-      "integrity": "sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ=="
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5094,9 +5115,9 @@
       "dev": true
     },
     "naughty-words": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/naughty-words/-/naughty-words-1.0.2.tgz",
-      "integrity": "sha512-ssI6oPhsPmZkKMWYdjiGSBAfcNs01L6BolUox4S1XQokdpf+1LsYeBpMdLo/RCJFc0PjSAF+MdvdRQzp4hndew=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/naughty-words/-/naughty-words-1.2.0.tgz",
+      "integrity": "sha512-0iadX6fN+3NsfvIRtWmmpEX9VsoIQ6n9FwyIxmew9w5yzFNqMgs/Ky0eAC/z5xXSHtqlVoByiovdROikwH9SXQ=="
     },
     "negotiator": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoid-good",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Obscene words filter for nanoid",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoid-good",
-  "version": "1.3.0",
+  "version": "3.0.0",
   "description": "Obscene words filter for nanoid",
   "main": "index.js",
   "scripts": {
@@ -15,14 +15,16 @@
   "author": "y-gagar1n",
   "license": "ISC",
   "dependencies": {
-    "nanoid": "^2.0.0",
-    "naughty-words": "^1.0.2"
+    "nanoid": "^3.1.2",
+    "naughty-words": "^1.2.0"
   },
   "devDependencies": {
     "jest": "^23.4.1",
     "size-limit": "^0.18.5"
   },
-  "size-limit": [{
-    "path": "index.js"
-  }]
+  "size-limit": [
+    {
+      "path": "index.js"
+    }
+  ]
 }

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -1,7 +1,6 @@
 var en = require('../locale/en');
-var nanoidGood = require('../async/')(en)
-var format = require('../async/format')(en)
-var generate = require('../async/generate')(en)
+var nanoidGood = require('../async/').nanoid(en);
+var customAlphabet = require('../async/').customAlphabet(en);
 
 it('default doesnt throw', function () {
     return nanoidGood().then(function(id) {
@@ -15,24 +14,8 @@ it('default doesnt throw when length specified', function () {
     });
 });
 
-
-it('format doesnt throw', function () {
-    var random = function(size) {
-        return new Promise(function(resolve) {
-            var result = [];
-            for (var i = 0; i < size; i++) result.push(Math.random() * 255);
-            resolve(result);
-        });
-    }
-
-    return format(random, "abcdef", 5)
-        .then(function(id) {
-            expect(typeof id).toEqual('string');
-        });
-});
-
-it('generate doesnt throw', function () {
-    return generate("1234567abcdef", 10).then(function(id) {
+it('customAlphabet doesnt throw', function () {
+    return customAlphabet("1234567abcdef", 10)().then(function(id) {
         expect(typeof id).toEqual('string');
     });
 });

--- a/test/hasProfanity.test.js
+++ b/test/hasProfanity.test.js
@@ -8,8 +8,18 @@ it('returns true on bad word', function () {
     expect(hasProfanity("aSs")).toEqual(true);
 });
 
+it('returns true on bad word with numbers', function () {
+    expect(hasProfanity("aS5")).toEqual(true);
+    expect(hasProfanity("p0rn")).toEqual(true);
+    expect(hasProfanity("sh1t")).toEqual(true);
+    expect(hasProfanity("3rotic")).toEqual(true);
+    expect(hasProfanity("camgir1")).toEqual(true);
+    expect(hasProfanity("8astard")).toEqual(true);
+});
+
 it('returns true on bad word in between of larger word', function () {
     expect(hasProfanity("abcaSsqwe")).toEqual(true);
+    expect(hasProfanity("abcaS5qwe")).toEqual(true);
 });
 
 it('returns true on bad word in non-english', function () {

--- a/test/non-secure.test.js
+++ b/test/non-secure.test.js
@@ -1,8 +1,8 @@
 var en = require('../locale/en');
-var nanoidGood = require('../').nanoid(en)
-var customAlphabet = require('../').customAlphabet(en)
-var customRandom = require('../').customRandom(en)
-var urlAlphabet = require('../').urlAlphabet;
+var nanoidGood = require('../non-secure').nanoid(en)
+var customAlphabet = require('../non-secure').customAlphabet(en)
+var customRandom = require('../non-secure').customRandom(en)
+var urlAlphabet = require('../non-secure').urlAlphabet;
 
 it('default doesnt throw', function () {
     var id = nanoidGood();

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var en = require('../locale/en');
+var de = require('../locale/de');
 var nanoidGood = require('../').nanoid(en)
 var customAlphabet = require('../').customAlphabet(en)
 var customRandom = require('../').customRandom(en)
@@ -20,8 +21,15 @@ it('customAlphabet doesnt throw', function () {
     expect(typeof id).toEqual('string')
 });
 
+it('customAlphabet doesnt throw with multiple languages', function () {
+    var generator = customAlphabet("1234567abcdef", 10)
+    var id = generator();
+    expect(typeof id).toEqual('string')
+});
+
 it('urlAlphabet passes through', function () {
-    var generator = customAlphabet(urlAlphabet, 10)
+    var customAlphabetWithLanguages = require('../').customAlphabet(en, de)
+    var generator = customAlphabetWithLanguages(urlAlphabet, 10)
     var id = generator();
     expect(typeof id).toEqual('string')
 });

--- a/wrapper.js
+++ b/wrapper.js
@@ -5,6 +5,7 @@ var wrapper = function (fn) {
         return function () {
             while (true) {
                 var id = fn.apply(this, arguments);
+                console.log(id)
                 if (!hasProfanity(locales)(id)) return id;
             }
         }

--- a/wrapper.js
+++ b/wrapper.js
@@ -5,7 +5,6 @@ var wrapper = function (fn) {
         return function () {
             while (true) {
                 var id = fn.apply(this, arguments);
-                console.log(id)
                 if (!hasProfanity(locales)(id)) return id;
             }
         }


### PR DESCRIPTION
- Refactor to match the exports and API of NanoID v3 - Breaking Changes, Fixes #9 
- Match numbers that look like letters against naughty words (i.e. `A5S` matches `ass`)